### PR TITLE
crossplatform save directory

### DIFF
--- a/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
+++ b/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
@@ -47,17 +47,23 @@ public class ConfigManager {
     private final List<ProfileData> profiles = new ArrayList<>();
     private Config config;
 
-    public ConfigManager(Path configDir) {
-        this.configDir = configDir;
-        this.configFile = configDir.resolve("config.json");
-        this.profilesDir = configDir.resolve("profiles");
-        this.iconsDir = configDir.resolve("icons");
-    }
-
     public ConfigManager(boolean isPortable) {
-        this(isPortable
-                ? Paths.get(System.getProperty("user.dir"))
-                : Paths.get(System.getProperty("user.home"), ".jmacros"));
+        if (isPortable) configDir = Paths.get(System.getProperty("user.dir"));
+        else {
+            Path configDir;
+            configDir = Paths.get(System.getProperty("user.home")).resolve(".jmacros");
+            if (System.getProperty("os.name").startsWith("mac"))
+                configDir = Paths.get(System.getProperty("user.home")).resolve("Library/Application Support/jmacros");
+
+            String xdgConfigHome = System.getenv().get("XDG_CONFIG_HOME");
+            if (!xdgConfigHome.isBlank()) configDir = Paths.get(xdgConfigHome).resolve("jmacros");
+
+            this.configDir = configDir;
+        }
+
+        configFile = configDir.resolve("config.json");
+        profilesDir = configDir.resolve("profiles");
+        iconsDir = configDir.resolve("icons");
     }
 
 

--- a/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
+++ b/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
@@ -55,8 +55,14 @@ public class ConfigManager {
             if (System.getProperty("os.name").startsWith("mac"))
                 configDir = Paths.get(System.getProperty("user.home")).resolve("Library/Application Support/jmacros");
 
-            String xdgConfigHome = System.getenv().get("XDG_CONFIG_HOME");
-            if (!xdgConfigHome.isBlank()) configDir = Paths.get(xdgConfigHome).resolve("jmacros");
+            String xdgConfigHome = System.getenv("XDG_CONFIG_HOME");
+            try {
+                if (xdgConfigHome != null && !xdgConfigHome.isBlank()) configDir = Paths.get(xdgConfigHome).resolve("jmacros");
+            } catch (InvalidPathException e) {
+                logger.error("XDG_CONFIG_HOME environment variable does not point to a valid path");
+                logger.error(e.getMessage(), e);
+                logger.info("Falling back to legacy dir");
+            }
 
             this.configDir = configDir;
         }

--- a/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
+++ b/core/src/main/java/io/github/joblo2213/JMacros/core/config/ConfigManager.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;


### PR DESCRIPTION
as discussed in #2, implement the "XDG Base directory" for linux as well as the "Library/Application Support" for mac; if windows or the variables arent found, default back to home